### PR TITLE
Add very basic handling of term and syllabus URLs.

### DIFF
--- a/project/basehandler.py
+++ b/project/basehandler.py
@@ -5,10 +5,6 @@ import urllib
 from google.appengine.ext import ndb
 from webapp2_extras import sessions, auth
 
-from user import User
-from syllabus import Syllabus
-from term import Term
-
 class BaseHandler(webapp2.RequestHandler):
     def dispatch(self):
         self.session_store = sessions.get_store(request = self.request)
@@ -20,6 +16,10 @@ class BaseHandler(webapp2.RequestHandler):
           
     @webapp2.cached_property
     def session(self):
+        from user import User
+        from syllabus import Syllabus
+        from term import Term
+
         session = self.session_store.get_session()
         
         user = User.query(User.isSelected == True).get()
@@ -45,7 +45,7 @@ class BaseHandler(webapp2.RequestHandler):
         else:
             u = User(isSelected = True)
             u.put()
-            t = Term(parent = u.key, isSelected = True)
+            t = Term(parent = u.key, isSelected = True, semester = 'F', year = 2015)
             t.put()
             s = Syllabus(parent = t.key, isSelected = True)
             s.put()

--- a/project/main.py
+++ b/project/main.py
@@ -36,7 +36,8 @@ import calendarEdit
 import policy
 import preview
 import scalesEdit
-import textbook    
+import textbook
+import term
      
 config = {}
 config['webapp2_extras.auth'] = {
@@ -44,7 +45,14 @@ config['webapp2_extras.auth'] = {
 }
 config['webapp2_extras.sessions'] = {
     'secret_key': 'secret_key',
-} 
+}
+
+# Regular expression to match a URL starting with a term name
+# [FfSsMmWw] - any one these characters may appear (case insensitive)
+#              F (Fall), S (Spring), M (Summer), W (Winterim)
+# [0-9][0-9] - two digit number for the year
+termRegex = '/([FfSsMmWw][0-9][0-9])'
+
 app = webapp2.WSGIApplication([
     ('/', MainHandler),
     ('/login', login.LoginHandler),
@@ -66,4 +74,6 @@ app = webapp2.WSGIApplication([
     ('/addpolicy', policy.AddHandler),
     ('/removepolicy', policy.RemoveHandler),
     ('/preview', preview.PreviewHandler),
+    (termRegex + '/*', term.WeeklyCalendarHandler),
+    (termRegex + '/(.*)', preview.ViewHandler),
 ], debug=True, config=config)

--- a/project/preview.html
+++ b/project/preview.html
@@ -3,13 +3,13 @@
     <head>
         <title>Syllablaster &gt; Syllabus Preview</title>
         
-        <link rel="stylesheet" type="text/css" href="stylesheets/calendarView.css">
-		<link rel="stylesheet" type="text/css" href="stylesheets/textbookView.css">
-		<link rel="stylesheet" type="text/css" href="stylesheets/assessmentView.css">
-		<link rel="stylesheet" type="text/css" href="stylesheets/instructorView.css">
-		<link rel="stylesheet" type="text/css" href="stylesheets/gradingScaleView.css">
-		<link rel="stylesheet" type="text/css" href="stylesheets/main.css">
-		<link rel="stylesheet" type="text/css" href="stylesheets/custom.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/calendarView.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/textbookView.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/assessmentView.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/instructorView.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/gradingScaleView.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/main.css">
+        <link rel="stylesheet" type="text/css" href="/stylesheets/custom.css">
     </head>
     
     <body>

--- a/project/preview.py
+++ b/project/preview.py
@@ -168,3 +168,16 @@ class PreviewHandler(BaseHandler):
                 'textbooks': Textbook.query(ancestor = syllabus.key).fetch(),
             }
         self.response.write(template.render(context))
+
+class ViewHandler(PreviewHandler):
+    def get(self, term, syllabus):
+        # TODO: Determine valid syllabus names
+        
+        # Deal with possible trailing slash
+        if syllabus[-1] == '/':
+            syllabus = syllabus[:-1]
+
+        if term.upper() == 'F15' and syllabus == 'cs361':
+            PreviewHandler.get(self)
+        else:
+            self.abort(404)

--- a/project/term.py
+++ b/project/term.py
@@ -1,4 +1,12 @@
+import os
 from google.appengine.ext import ndb
+from jinja2 import Environment, FileSystemLoader
+from basehandler import BaseHandler
+
+jinja_env = Environment(
+  loader=FileSystemLoader(os.path.dirname(__file__)),
+  extensions=['jinja2.ext.autoescape'],
+  autoescape=True)
 
 class Term(ndb.Model):
     semester = ndb.StringProperty()
@@ -9,3 +17,20 @@ class Term(ndb.Model):
     def syllabi(self):
         from syllabus import Syllabus
         return Syllabus.query(ancestor = self.key).fetch()
+        
+class WeeklyCalendarHandler(BaseHandler):
+    def get(self, term):
+        # TODO: Render weekly calendar template
+        
+        term = term.upper()
+        userKey = self.session.get('user')
+        user = ndb.Key(urlsafe = userKey).get()
+        terms = Term.query(ancestor = user.key).fetch()
+        
+        for t in terms:
+            if term[0] == t.semester and int('20' + term[1:3]) == t.year:
+                self.response.write('Valid term in datastore')
+                return
+        
+        # Raise HTTP 404 error for terms not yet available
+        self.abort(404)


### PR DESCRIPTION
This adds some basic handling for term and syllabus URLs, such as http://blah/F15 (needed for weekly calendar) and http://blah/F15/cs361(needed for public URL to syllabus)

This raises the question of where the course name and section number should be. I think we had these fields before but they got lost in the switch from Course to Term. We need some way of figuring out valid syllabus names. For now, I've hardcoded it to look for "cs361" here.
