### PR TITLE
Fix login page when user has no pre-existing cookie.

### DIFF
--- a/project/basehandler.py
+++ b/project/basehandler.py
@@ -34,7 +34,7 @@ class BaseHandler(webapp2.RequestHandler):
 def login_required(handler):
     def check_login(self, *args, **kwargs):
         auth = self.auth
-        if not self.session['user']:
+        if not self.session.get('user'):
             return self.redirect('/login')
         else:
             return handler(self, *args, **kwargs)


### PR DESCRIPTION
I ran into an issue when it redirected to the login page from a browser that hadn't logged in before. The error was concerning the fact that 'user' key didn't exist in the session dictionary yet. Using get() will return None when there is not user in the session yet.
