### PR TITLE
Fix logout functionality and really remove user tokens from datastore.

### DIFF
--- a/project/logout.py
+++ b/project/logout.py
@@ -13,8 +13,6 @@ template_env = jinja2.Environment(
 class LogoutHandler(BaseHandler):
 	@login_required
 	def get(self):
-		self.session['term'] = None
-		self.session['syllabus'] = None
-		self.session['user'] = None
-		self.auth.unset_session
+		self.auth.unset_session()
+		self.session.clear()
 		self.redirect('/login')


### PR DESCRIPTION
Turns out the parentheses were missing on unset_session so it wasn't actually calling it. Now the user tokens are actually deleted from the data store when you logout.
