### PR TITLE
Add signup error messages

### DIFF
--- a/project/signup.html
+++ b/project/signup.html
@@ -3,13 +3,21 @@
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<title> SyllaBlaster </title>
+		<link rel="stylesheet" type="text/css" href="/stylesheets/main.css" />
 		<link rel="stylesheet" type="text/css" href="/stylesheets/login.css" />
 	</head>
 	<body>
 		<h2> Sign up for SyllaBlaster </h2>
+		{% if errors %}
+		<ul id="error">
+		{% for error in errors %}
+			<li>{{ error }}</li>
+		{% endfor %}
+		</ul>
+		{% endif %}
 		<div id="signupBox">
 			<form method="post" action="/signup">
-				<input type="text" placeholder="Username" name="usernameSignup" id="usernameSignup" required /> <br />
+				<input type="text" placeholder="Username" name="usernameSignup" id="usernameSignup" value="{{ username }}" required /> <br />
 				<!--
 				Email
 				<input type="text" name="emailSignup" id="emailSignup" requirted /> <br />

--- a/project/signup.py
+++ b/project/signup.py
@@ -1,5 +1,6 @@
 import webapp2
 import jinja2
+import re
 import os
 from webapp2_extras import auth
 
@@ -26,31 +27,45 @@ class SignupForm(Form):
 '''
 
 class SignupHandler(BaseHandler):
-    def get(self):
+    def render(self, errors = None, username = ''):
         template = template_env.get_template('signup.html')
         context = {
-            
+            'errors': errors,
+            'username': username
         }
         self.response.write(template.render(context))
-        
+
+    def get(self):
+        self.render()
+
     def post(self):
         username = self.request.get('usernameSignup')
         email = self.request.get('emailSignup')
         password = self.request.get('passwordSignup')
         confirm = self.request.get('confirmSignup')
-        
+        errors = []
+
+        if not username:
+            errors.append('Username field must not be empty')
+        elif len(username) < 3:
+            errors.append('Username must be at least 3 characters long')
+        elif self.auth.store.user_model.get_by_auth_id(username):
+            errors.append('Username "' + username + '" already exists')
+        elif not re.match('^[\w_]+$', username):
+            errors.append('Username must only contain alphanumeric characters (letters A-Z or numbers 0-9) or underscores (_)')
+        if not password:
+            errors.append('Password field must not be empty')
+        elif len(password) < 8:
+            errors.append('Password must be at least 8 characters long')
         if password != confirm:
-            self.redirect('/signup')
-            return
-        
+            errors.append('Password and Confirm Password fields must match')
+
+        if errors:
+            return self.render(errors, username)
+
         success, info = self.auth.store.user_model.create_user(username, password_raw = password)
-        
+
         if success:
             return self.redirect('/login')
-        else:
-            '''
-            Errors errors errors
-            '''
-            print "error"
-        
-        self.redirect('/signup')
+
+        return self.render(['Unexpected error creating user'])

--- a/project/signup.py
+++ b/project/signup.py
@@ -41,6 +41,7 @@ class SignupHandler(BaseHandler):
         
         if password != confirm:
             self.redirect('/signup')
+            return
         
         success, info = self.auth.store.user_model.create_user(username, password_raw = password)
         


### PR DESCRIPTION
This adds the following possible error messages to the sign up page:
- Empty username
- Empty password
- Password and confirm password do not match
- Username must be at least 3 characters
- Username must be alphanumeric or have underscores
- Password must be at least 8 characters
- Username already exists
