### PR TITLE
Fix background color on term page

### DIFF
--- a/project/stylesheets/term.css
+++ b/project/stylesheets/term.css
@@ -1,0 +1,5 @@
+body {   
+	font-family: Sans-serif;
+	font-size: 1.3em;
+	background-color: #4E98A0;
+}

--- a/project/term.html
+++ b/project/term.html
@@ -14,6 +14,7 @@
 		<title>SyllaBlaster - {{ semesterName }} {{ term.year }}</title>
 		<link rel="stylesheet" type="text/css" href="/stylesheets/main.css" />
 		<link rel="stylesheet" type="text/css" href="/stylesheets/list.css" />
+		<link rel="stylesheet" type="text/css" href="/stylesheets/term.css" />
 	</head>
 	<body>
         {% if term %}


### PR DESCRIPTION
The term page (like http://blah/user/S16) became unreadable with the recent style changes. This fixes the background color on this page to make it the usual color that's being used on the login/signup pages and elsewhere. 
